### PR TITLE
fix: don't resolve symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ cage [flags] <command> [args...]
 #### Run a script with temporary directory access
 ```bash
 cage -allow /tmp python analyze.py input.txt
+# Note: On macOS, /tmp is a symlink to /private/tmp
+# You may need to use: cage -allow /private/tmp python analyze.py input.txt
 ```
 
 #### Build a project with restricted output directories
@@ -148,7 +150,7 @@ presets:
   custom:
     allow:
       - "./output"
-      - "/tmp"
+      - "/tmp"  # Note: On macOS, use /private/tmp instead
       - "~/.myapp"
 ```
 
@@ -231,7 +233,7 @@ cage -allow ./reports -- python generate_report.py /confidential/data.csv
 ```bash
 cage \
   -allow . \                                   # Allow current directory
-  -allow /tmp \                                # Allow temporary directory
+  -allow /tmp \                                # Allow temporary directory (on macOS, use /private/tmp)
   -allow $HOME/.npm \                          # Allow npm directory for MCP server executed via npx command
   -allow "$CLAUDE_CONFIG_DIR" \                # Allow Claude config directory
   -allow "$(git rev-parse --git-common-dir)" \ # Allow git common directory

--- a/sandbox_darwin.go
+++ b/sandbox_darwin.go
@@ -73,15 +73,8 @@ func generateSandboxProfile(config *SandboxConfig) (string, error) {
 			absPath = path
 		}
 
-		// Resolve symlinks to get the real path
-		realPath, err := filepath.EvalSymlinks(absPath)
-		if err != nil {
-			// If we can't resolve symlinks (e.g., path doesn't exist yet), use the absolute path
-			realPath = absPath
-		}
-
 		// Escape the path for the sandbox profile
-		escapedPath := escapePathForSandbox(realPath)
+		escapedPath := escapePathForSandbox(absPath)
 
 		// Allow writes to the path and all subpaths
 		fmt.Fprintf(&profile, "(allow file-write* (subpath \"%s\"))\n", escapedPath)


### PR DESCRIPTION
This pull request includes updates to improve macOS compatibility by addressing symlink handling and documentation, as well as simplifying the sandbox profile generation logic. The most important changes involve clarifying macOS-specific path usage in the documentation and removing symlink resolution in the sandbox configuration.

### Documentation updates for macOS compatibility:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R59): Added notes to clarify that `/tmp` is a symlink to `/private/tmp` on macOS and updated examples accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R153) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L234-R236)

### Simplification of sandbox profile generation:

* [`sandbox_darwin.go`](diffhunk://#diff-4f6e952888d22d47b4c93e4955f544aee519c09483279bc35af3aa8e088089b7L76-R77): Removed symlink resolution logic (`filepath.EvalSymlinks`) and directly used absolute paths for sandbox profile generation, simplifying the code.