### PR TITLE
ci: run go test in the CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,4 +31,5 @@ jobs:
           go-version-file: 'go.mod'
           cache: "${{ github.event_name == 'push' }}"
       - run: go build
+      - run: go test -v ./...
       - run: ./test_e2e.sh


### PR DESCRIPTION
I added `config_test.go`, so we have to run go test in the CI.