### PR TITLE
docs: use $HOME istead of tilda and add claude-code preset example

### DIFF
--- a/CLI_DESIGN.md
+++ b/CLI_DESIGN.md
@@ -27,7 +27,7 @@ cage [flags] -- <command> [command-flags] [command-args...]
 
 ```bash
 --allow <path>     # Grant write access to specific paths (can be used multiple times)
-                   # Example: --allow /tmp --allow ~/output
+                   # Example: --allow /tmp --allow $HOME/output
 ```
 
 ## Usage Examples
@@ -42,7 +42,7 @@ cage ls -la
 cage --allow /tmp python script.py
 
 # Allow writing to multiple directories
-cage --allow /tmp --allow ~/output -- npm run build
+cage --allow /tmp --allow $HOME/output -- npm run build
 
 # Run in investigation mode (no restrictions)
 cage --allow-all make install
@@ -107,7 +107,7 @@ cage --allow ./dist -- npm run build
 cage python suspicious_script.py
 
 # Test third-party tools with minimal permissions
-cage --allow ~/safe-output -- third-party-tool process data.json
+cage --allow $HOME/safe-output -- third-party-tool process data.json
 ```
 
 ### Data Processing

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cage -preset npm -allow ./logs npm run test
 cage -list-presets
 
 # Use custom configuration file
-cage -config ~/my-presets.yaml -preset custom-preset ./script.sh
+cage -config $HOME/my-presets.yaml -preset custom-preset ./script.sh
 ```
 
 ### Configuration File
@@ -118,8 +118,8 @@ Cage supports YAML configuration files to define presets. The configuration file
 3. `$XDG_CONFIG_HOME/cage/presets.yml` (or platform-specific config directory)
 
 The default config directory is:
-- Linux: `~/.config/cage/`
-- macOS: `~/Library/Application Support/cage/`
+- Linux: `$HOME/.config/cage/`
+- macOS: `$HOME/Library/Application Support/cage/`
 - Windows: `%APPDATA%\cage\`
 
 Example configuration file:
@@ -129,21 +129,21 @@ presets:
   npm:
     allow:
       - "."
-      - "~/.npm"
-      - "~/.cache/npm"
-      - "~/.npmrc"
+      - "$HOME/.npm"
+      - "$HOME/.cache/npm"
+      - "$HOME/.npmrc"
   
   cargo:
     allow:
       - "."
-      - "~/.cargo"
-      - "~/.rustup"
-      - "~/.cache/sccache"
+      - "$HOME/.cargo"
+      - "$HOME/.rustup"
+      - "$HOME/.cache/sccache"
   
   git-enabled:
     allow:
       - "."
-      - "~/.ssh"
+      - "$HOME/.ssh"
     allow-git: true
     allow-keychain: true  # macOS only
   
@@ -151,7 +151,7 @@ presets:
     allow:
       - "./output"
       - "/tmp"  # Note: On macOS, use /private/tmp instead
-      - "~/.myapp"
+      - "$HOME/.myapp"
 ```
 
 Presets support the following options:

--- a/examples/presets.yaml
+++ b/examples/presets.yaml
@@ -59,3 +59,17 @@ presets:
       - "/opt/homebrew"
       - "$HOME/Library/Caches/Homebrew"
       - "$HOME/Library/Logs/Homebrew"
+
+  claude-code:
+    allow:
+      - "."
+      - "/tmp" # on Linux
+      - "/private/tmp" # on macOS
+      - "/dev/tty"
+      - "$HOME/.claude"
+      - "$HOME/.claude.json"
+      - "$HOME/.claude.json.backup"
+      - "$HOME/.claude.json.lock"
+      - "$HOME/.claude.lock"
+    allow-keychain: true
+    allow-git: true

--- a/examples/presets.yaml
+++ b/examples/presets.yaml
@@ -2,53 +2,53 @@ presets:
   npm:
     allow:
       - "."
-      - "~/.npm"
-      - "~/.cache/npm"
-      - "~/.npmrc"
+      - "$HOME/.npm"
+      - "$HOME/.cache/npm"
+      - "$HOME/.npmrc"
   
   cargo:
     allow:
       - "."
-      - "~/.cargo"
-      - "~/.rustup"
-      - "~/.cache/sccache"
+      - "$HOME/.cargo"
+      - "$HOME/.rustup"
+      - "$HOME/.cache/sccache"
   
   pip:
     allow:
       - "."
-      - "~/.cache/pip"
-      - "~/.local"
-      - "~/Library/Caches/pip"
+      - "$HOME/.cache/pip"
+      - "$HOME/.local"
+      - "$HOME/Library/Caches/pip"
   
   go:
     allow:
       - "."
-      - "~/go"
-      - "~/.cache/go-build"
+      - "$HOME/go"
+      - "$HOME/.cache/go-build"
   
   node:
     allow:
       - "."
-      - "~/.npm"
-      - "~/.cache/npm"
-      - "~/.npmrc"
+      - "$HOME/.npm"
+      - "$HOME/.cache/npm"
+      - "$HOME/.npmrc"
       - "node_modules"
   
   ruby:
     allow:
       - "."
-      - "~/.gem"
-      - "~/.bundle"
-      - "~/.rbenv"
-      - "~/.rvm"
+      - "$HOME/.gem"
+      - "$HOME/.bundle"
+      - "$HOME/.rbenv"
+      - "$HOME/.rvm"
   
   python:
     allow:
       - "."
-      - "~/.pyenv"
-      - "~/.cache/pip"
-      - "~/.local"
-      - "~/.virtualenvs"
+      - "$HOME/.pyenv"
+      - "$HOME/.cache/pip"
+      - "$HOME/.local"
+      - "$HOME/.virtualenvs"
       - "venv"
       - ".venv"
   
@@ -57,5 +57,5 @@ presets:
       - "."
       - "/usr/local/Homebrew"
       - "/opt/homebrew"
-      - "~/Library/Caches/Homebrew"
-      - "~/Library/Logs/Homebrew"
+      - "$HOME/Library/Caches/Homebrew"
+      - "$HOME/Library/Logs/Homebrew"


### PR DESCRIPTION
This PR does below two things
1. use $HOME instead of `~`
    - `~` is not expanded in the presets. We can use it from command line arguments because the shell expands it. I choose to use $HOME in docs for consistency.
2. Add example preset for claude-code