### PR TITLE
feat: add -dry-run option

### DIFF
--- a/dryrun_darwin.go
+++ b/dryrun_darwin.go
@@ -1,0 +1,76 @@
+//go:build darwin
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// showDryRun displays the sandbox profile that would be generated for the given configuration
+func showDryRun(config *SandboxConfig) error {
+	fmt.Println("Sandbox Profile (dry-run):")
+	fmt.Println("========================================")
+	fmt.Println("Version: macOS Sandbox v1")
+	fmt.Println("Base profile: system.sb")
+	fmt.Println()
+	fmt.Println("Rules:")
+
+	if config.AllowAll {
+		fmt.Println("- Allow all operations (--allow-all flag)")
+	} else {
+		fmt.Println("- Allow all operations by default")
+		fmt.Println("- Deny all file writes")
+		fmt.Println("- Allow writes to:")
+		fmt.Println("  * System temporary directories")
+
+		if config.AllowKeychain {
+			fmt.Println("  * Keychain directories (--allow-keychain)")
+		}
+
+		// Process allowed paths
+		for _, path := range config.AllowedPaths {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				absPath = path
+			}
+			source := "user specified"
+			if config.AllowGit && strings.Contains(path, ".git") {
+				source = "--allow-git"
+			}
+			fmt.Printf("  * %s (%s)\n", absPath, source)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Raw profile:")
+	fmt.Println("----------------------------------------")
+
+	// Generate and display the actual profile
+	profile, err := generateSandboxProfile(config)
+	if err != nil {
+		return fmt.Errorf("generate sandbox profile: %w", err)
+	}
+	fmt.Print(profile)
+	fmt.Println("----------------------------------------")
+
+	fmt.Println()
+	fmt.Printf("Command: %s", config.Command)
+	if len(config.Args) > 0 {
+		fmt.Printf(" %s", strings.Join(config.Args, " "))
+	}
+	fmt.Println()
+
+	return nil
+}
+
+// printDryRunAndExit displays the dry-run information and exits
+func printDryRunAndExit(config *SandboxConfig) {
+	if err := showDryRun(config); err != nil {
+		fmt.Fprintf(os.Stderr, "cage: error showing dry-run: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/dryrun_linux.go
+++ b/dryrun_linux.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// showDryRun displays the sandbox configuration that would be applied for the given configuration
+func showDryRun(config *SandboxConfig) error {
+	fmt.Println("Sandbox Profile (dry-run):")
+	fmt.Println("========================================")
+	fmt.Println("Platform: Linux")
+	fmt.Println("Technology: Landlock LSM")
+	fmt.Println()
+	fmt.Println("Note: On Linux, cage uses Landlock LSM instead of sandbox-exec.")
+	fmt.Println("The following restrictions would be applied:")
+	fmt.Println()
+	fmt.Println("Rules:")
+
+	if config.AllowAll {
+		fmt.Println("- Allow all operations (--allow-all flag)")
+	} else {
+		fmt.Println("- Allow read access to all files")
+		fmt.Println("- Deny write access except to:")
+		fmt.Println("  * /dev/null (for discarding output)")
+
+		// Process allowed paths
+		for _, path := range config.AllowedPaths {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				absPath = path
+			}
+			source := "user specified"
+			if config.AllowGit && strings.Contains(path, ".git") {
+				source = "--allow-git"
+			}
+			fmt.Printf("  * %s (%s)\n", absPath, source)
+		}
+	}
+
+	fmt.Println()
+	fmt.Printf("Command: %s", config.Command)
+	if len(config.Args) > 0 {
+		fmt.Printf(" %s", strings.Join(config.Args, " "))
+	}
+	fmt.Println()
+
+	return nil
+}
+
+// printDryRunAndExit displays the dry-run information and exits
+func printDryRunAndExit(config *SandboxConfig) {
+	if err := showDryRun(config); err != nil {
+		fmt.Fprintf(os.Stderr, "cage: error showing dry-run: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/dryrun_linux.go
+++ b/dryrun_linux.go
@@ -16,7 +16,6 @@ func showDryRun(config *SandboxConfig) error {
 	fmt.Println("Platform: Linux")
 	fmt.Println("Technology: Landlock LSM")
 	fmt.Println()
-	fmt.Println("Note: On Linux, cage uses Landlock LSM instead of sandbox-exec.")
 	fmt.Println("The following restrictions would be applied:")
 	fmt.Println()
 	fmt.Println("Rules:")

--- a/dryrun_other.go
+++ b/dryrun_other.go
@@ -1,0 +1,23 @@
+//go:build !darwin && !linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// showDryRun displays an error that cage is not supported on this platform
+func showDryRun(config *SandboxConfig) error {
+	return fmt.Errorf("cage is not supported on %s", runtime.GOOS)
+}
+
+// printDryRunAndExit displays the dry-run information and exits
+func printDryRunAndExit(config *SandboxConfig) {
+	if err := showDryRun(config); err != nil {
+		fmt.Fprintf(os.Stderr, "cage: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type flags struct {
 	listPresets   bool
 	configPath    string
 	version       bool
+	dryRun        bool
 }
 
 func parseFlags() (*flags, []string) {
@@ -93,6 +94,13 @@ func parseFlags() (*flags, []string) {
 		"version",
 		false,
 		"Print version information and exit",
+	)
+
+	flag.BoolVar(
+		&f.dryRun,
+		"dry-run",
+		false,
+		"Show the generated sandbox profile without executing",
 	)
 
 	flag.Parse()
@@ -234,6 +242,11 @@ func main() {
 		AllowedPaths:  allowedPaths,
 		Command:       args[0],
 		Args:          args[1:],
+	}
+
+	// Handle dry-run flag
+	if flags.dryRun {
+		printDryRunAndExit(sandboxConfig)
 	}
 
 	// Execute in sandbox


### PR DESCRIPTION
This pull request introduces a new "dry-run" feature to display the sandbox profile or configuration without executing it. The feature is implemented for macOS, Linux, and other platforms, with platform-specific behavior. Additionally, a new `-dry-run` flag is added to the CLI to enable this feature.

### New "dry-run" feature:

* **macOS support**: Added `dryrun_darwin.go` to implement a `showDryRun` function that displays the sandbox profile, including rules and raw profile details, specific to macOS.
* **Linux support**: Added `dryrun_linux.go` to implement a `showDryRun` function that displays the sandbox configuration, including rules and restrictions, specific to Linux using Landlock LSM.
* **Unsupported platforms**: Added `dryrun_other.go` to handle unsupported platforms by displaying an error message indicating the platform is not supported.

### CLI enhancements:

* **New `-dry-run` flag**: Added a `dryRun` field to the `flags` struct and registered a `--dry-run` CLI flag to enable the dry-run feature. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R35) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R99-R105)
* **Flag handling in `main`**: Updated the `main` function to check for the `--dry-run` flag and invoke the `printDryRunAndExit` function if the flag is set.