### PR TITLE
feat: eval-symlinks option for presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,45 @@ presets:
 ```
 
 Presets support the following options:
-- `allow`: List of paths to grant write access
+- `allow`: List of paths to grant write access (can be strings or objects with `eval-symlinks` option)
 - `allow-git`: Enable access to git common directory (boolean)
 - `allow-keychain`: Enable macOS keychain access (boolean)
+
+#### Symlink Evaluation in Presets
+
+The `allow` field in presets supports both simple string paths and objects with an `eval-symlinks` option. When `eval-symlinks` is set to `true`, the symlink will be resolved to its target path before granting access.
+
+```yaml
+presets:
+  symlink-aware:
+    allow:
+      # Simple string (default: eval-symlinks = false)
+      - "./direct-path"
+      
+      # Object with eval-symlinks option
+      - path: "/tmp"
+        eval-symlinks: true  # Resolves symlink to actual path
+      
+      # Mixed usage
+      - "$HOME/.cache"
+      - path: "$HOME/.local/share"
+        eval-symlinks: true
+```
+
+This is particularly useful when:
+- Working with tools that create symlinks to actual data directories
+- macOS's `/tmp` is a symlink to `/private/tmp`
+- Using symlinked configuration directories
+- Working with package managers that use symlinks
+
+Example use case for macOS:
+```yaml
+presets:
+  macos-tmp:
+    allow:
+      - path: "/tmp"
+        eval-symlinks: true  # Automatically resolves to /private/tmp
+```
 
 #### Auto-Presets
 

--- a/config.go
+++ b/config.go
@@ -24,8 +24,8 @@ type Preset struct {
 }
 
 type AllowPath struct {
-	Path        string `yaml:"path"`
-	EvalSymLink bool   `yaml:"eval-symlink,omitempty"`
+	Path         string `yaml:"path"`
+	EvalSymLinks bool   `yaml:"eval-symlinks,omitempty"`
 }
 
 type AutoPresetRule struct {
@@ -42,8 +42,8 @@ func (p *AllowPath) UnmarshalYAML(b []byte) error {
 	switch v := a.(type) {
 	case string:
 		*p = AllowPath{
-			Path:        v,
-			EvalSymLink: false,
+			Path:         v,
+			EvalSymLinks: false,
 		}
 		return nil
 	case map[string]any:
@@ -193,8 +193,8 @@ func (p *Preset) ProcessPreset() (*Preset, error) {
 	// Expand environment variables in paths
 	for _, path := range p.Allow {
 		expanded := os.ExpandEnv(path.Path)
-		if path.EvalSymLink {
-			// Resolve symlinks if EvalSymLink is true
+		if path.EvalSymLinks {
+			// Resolve symlinks if EvalSymLinks is true
 			resolvedPath, err := filepath.EvalSymlinks(expanded)
 			if err != nil {
 				resolvedPath = expanded // Fallback to original path if eval fails

--- a/config_test.go
+++ b/config_test.go
@@ -607,37 +607,37 @@ func TestAllowPathUnmarshalYAML(t *testing.T) {
 			name: "string format",
 			yaml: `"/tmp/test"`,
 			want: AllowPath{
-				Path:        "/tmp/test",
-				EvalSymLink: false,
+				Path:         "/tmp/test",
+				EvalSymLinks: false,
 			},
 			wantErr: false,
 		},
 		{
-			name: "object format with eval-symlink false",
+			name: "object format with eval-symlinks false",
 			yaml: `path: "/tmp/test"
-eval-symlink: false`,
+eval-symlinks: false`,
 			want: AllowPath{
-				Path:        "/tmp/test",
-				EvalSymLink: false,
+				Path:         "/tmp/test",
+				EvalSymLinks: false,
 			},
 			wantErr: false,
 		},
 		{
-			name: "object format with eval-symlink true",
+			name: "object format with eval-symlinks true",
 			yaml: `path: "/tmp/test"
-eval-symlink: true`,
+eval-symlinks: true`,
 			want: AllowPath{
-				Path:        "/tmp/test",
-				EvalSymLink: true,
+				Path:         "/tmp/test",
+				EvalSymLinks: true,
 			},
 			wantErr: false,
 		},
 		{
-			name: "object format without eval-symlink",
+			name: "object format without eval-symlinks",
 			yaml: `path: "/tmp/test"`,
 			want: AllowPath{
-				Path:        "/tmp/test",
-				EvalSymLink: false,
+				Path:         "/tmp/test",
+				EvalSymLinks: false,
 			},
 			wantErr: false,
 		},
@@ -655,7 +655,7 @@ eval-symlink: true`,
 		},
 		{
 			name:     "invalid yaml",
-			yaml:     `{path: "/tmp", eval-symlink: [invalid}`,
+			yaml:     `{path: "/tmp", eval-symlinks: [invalid}`,
 			wantErr:  true,
 			errMatch: "',' or ']' must be specified",
 		},
@@ -686,11 +686,11 @@ eval-symlink: true`,
 				if ap.Path != tt.want.Path {
 					t.Errorf("UnmarshalYAML() Path = %v, want %v", ap.Path, tt.want.Path)
 				}
-				if ap.EvalSymLink != tt.want.EvalSymLink {
+				if ap.EvalSymLinks != tt.want.EvalSymLinks {
 					t.Errorf(
-						"UnmarshalYAML() EvalSymLink = %v, want %v",
-						ap.EvalSymLink,
-						tt.want.EvalSymLink,
+						"UnmarshalYAML() EvalSymLinks = %v, want %v",
+						ap.EvalSymLinks,
+						tt.want.EvalSymLinks,
 					)
 				}
 			}
@@ -706,9 +706,9 @@ func TestLoadConfigWithAllowPathFormats(t *testing.T) {
     allow:
       - "/tmp"
       - path: "/var"
-        eval-symlink: false
+        eval-symlinks: false
       - path: "/home/user"
-        eval-symlink: true`
+        eval-symlinks: true`
 	os.WriteFile(configPath, []byte(content), 0o644)
 
 	config, err := loadConfig(configPath)
@@ -726,18 +726,18 @@ func TestLoadConfigWithAllowPathFormats(t *testing.T) {
 	}
 
 	// Check first path (string format)
-	if preset.Allow[0].Path != "/tmp" || preset.Allow[0].EvalSymLink != false {
-		t.Errorf("first path = %+v, want {Path: /tmp, EvalSymLink: false}", preset.Allow[0])
+	if preset.Allow[0].Path != "/tmp" || preset.Allow[0].EvalSymLinks != false {
+		t.Errorf("first path = %+v, want {Path: /tmp, EvalSymLinks: false}", preset.Allow[0])
 	}
 
-	// Check second path (object format, eval-symlink: false)
-	if preset.Allow[1].Path != "/var" || preset.Allow[1].EvalSymLink != false {
-		t.Errorf("second path = %+v, want {Path: /var, EvalSymLink: false}", preset.Allow[1])
+	// Check second path (object format, eval-symlinks: false)
+	if preset.Allow[1].Path != "/var" || preset.Allow[1].EvalSymLinks != false {
+		t.Errorf("second path = %+v, want {Path: /var, EvalSymLinks: false}", preset.Allow[1])
 	}
 
-	// Check third path (object format, eval-symlink: true)
-	if preset.Allow[2].Path != "/home/user" || preset.Allow[2].EvalSymLink != true {
-		t.Errorf("third path = %+v, want {Path: /home/user, EvalSymLink: true}", preset.Allow[2])
+	// Check third path (object format, eval-symlinks: true)
+	if preset.Allow[2].Path != "/home/user" || preset.Allow[2].EvalSymLinks != true {
+		t.Errorf("third path = %+v, want {Path: /home/user, EvalSymLinks: true}", preset.Allow[2])
 	}
 }
 
@@ -769,7 +769,7 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 			name: "symlink evaluation disabled",
 			preset: Preset{
 				Allow: []AllowPath{
-					{Path: symlinkPath, EvalSymLink: false},
+					{Path: symlinkPath, EvalSymLinks: false},
 				},
 			},
 			wantPaths: []string{symlinkPath},
@@ -778,7 +778,7 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 			name: "symlink evaluation enabled",
 			preset: Preset{
 				Allow: []AllowPath{
-					{Path: symlinkPath, EvalSymLink: true},
+					{Path: symlinkPath, EvalSymLinks: true},
 				},
 			},
 			wantPaths: []string{resolvedTargetDir},
@@ -787,9 +787,9 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 			name: "mix of symlink and regular paths",
 			preset: Preset{
 				Allow: []AllowPath{
-					{Path: "/tmp", EvalSymLink: false},
-					{Path: symlinkPath, EvalSymLink: true},
-					{Path: "/var", EvalSymLink: false},
+					{Path: "/tmp", EvalSymLinks: false},
+					{Path: symlinkPath, EvalSymLinks: true},
+					{Path: "/var", EvalSymLinks: false},
 				},
 			},
 			wantPaths: []string{"/tmp", resolvedTargetDir, "/var"},
@@ -798,7 +798,7 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 			name: "non-existent symlink falls back to original path",
 			preset: Preset{
 				Allow: []AllowPath{
-					{Path: "/non/existent/symlink", EvalSymLink: true},
+					{Path: "/non/existent/symlink", EvalSymLinks: true},
 				},
 			},
 			wantPaths: []string{"/non/existent/symlink"},

--- a/config_test.go
+++ b/config_test.go
@@ -91,7 +91,7 @@ func TestConfigGetPreset(t *testing.T) {
 	config := &Config{
 		Presets: map[string]Preset{
 			"test": {
-				Allow: []string{"/tmp", "/var"},
+				Allow: []AllowPath{{Path: "/tmp"}, {Path: "/var"}},
 			},
 		},
 	}
@@ -132,9 +132,9 @@ func TestConfigGetPreset(t *testing.T) {
 func TestConfigListPresets(t *testing.T) {
 	config := &Config{
 		Presets: map[string]Preset{
-			"npm":   {Allow: []string{"~/.npm"}},
-			"cargo": {Allow: []string{"~/.cargo"}},
-			"pip":   {Allow: []string{"~/.pip"}},
+			"npm":   {Allow: []AllowPath{{Path: "~/.npm"}}},
+			"cargo": {Allow: []AllowPath{{Path: "~/.cargo"}}},
+			"pip":   {Allow: []AllowPath{{Path: "~/.pip"}}},
 		},
 	}
 
@@ -225,10 +225,10 @@ func TestProcessPreset(t *testing.T) {
 		{
 			name: "preset with environment variables",
 			preset: Preset{
-				Allow: []string{
-					"$HOME/.npm",
-					"${TEST_DIR}/data",
-					"/tmp",
+				Allow: []AllowPath{
+					{Path: "$HOME/.npm"},
+					{Path: "${TEST_DIR}/data"},
+					{Path: "/tmp"},
 				},
 				AllowKeychain: true,
 			},
@@ -242,8 +242,8 @@ func TestProcessPreset(t *testing.T) {
 		{
 			name: "preset with command substitution not expanded",
 			preset: Preset{
-				Allow: []string{
-					"$(echo /dynamic/path)",
+				Allow: []AllowPath{
+					{Path: "$(echo /dynamic/path)"},
 				},
 			},
 			wantPaths: []string{
@@ -272,8 +272,13 @@ func TestProcessPreset(t *testing.T) {
 				}
 
 				for i, got := range processed.Allow {
-					if got != tt.wantPaths[i] {
-						t.Errorf("ProcessPreset() path[%d] = %v, want %v", i, got, tt.wantPaths[i])
+					if got.Path != tt.wantPaths[i] {
+						t.Errorf(
+							"ProcessPreset() path[%d] = %v, want %v",
+							i,
+							got.Path,
+							tt.wantPaths[i],
+						)
 					}
 				}
 
@@ -343,9 +348,9 @@ func TestProcessPresetWithAllowGit(t *testing.T) {
 	// This test will only check the AllowGit flag is preserved
 	// We can't easily test the git directory addition without a real git repo
 	preset := Preset{
-		Allow: []string{
-			"$HOME/.npm",
-			"/tmp",
+		Allow: []AllowPath{
+			{Path: "$HOME/.npm"},
+			{Path: "/tmp"},
 		},
 		AllowKeychain: true,
 		AllowGit:      true,
@@ -387,8 +392,8 @@ func TestProcessPresetWithAllowGit(t *testing.T) {
 	}
 
 	for i, expected := range expectedPaths {
-		if processed.Allow[i] != expected {
-			t.Errorf("ProcessPreset() path[%d] = %v, want %v", i, processed.Allow[i], expected)
+		if processed.Allow[i].Path != expected {
+			t.Errorf("ProcessPreset() path[%d] = %v, want %v", i, processed.Allow[i].Path, expected)
 		}
 	}
 }
@@ -396,9 +401,9 @@ func TestProcessPresetWithAllowGit(t *testing.T) {
 func TestGetAutoPresets(t *testing.T) {
 	config := &Config{
 		Presets: map[string]Preset{
-			"claude-code": {Allow: []string{"/tmp"}},
-			"npm":         {Allow: []string{"~/.npm"}},
-			"python":      {Allow: []string{"~/.python"}},
+			"claude-code": {Allow: []AllowPath{{Path: "/tmp"}}},
+			"npm":         {Allow: []AllowPath{{Path: "~/.npm"}}},
+			"python":      {Allow: []AllowPath{{Path: "~/.python"}}},
 		},
 		AutoPresets: []AutoPresetRule{
 			{

--- a/main.go
+++ b/main.go
@@ -202,14 +202,14 @@ func main() {
 
 		// Add preset paths, checking for duplicates
 		for _, path := range processedPreset.Allow {
-			absPath, err := filepath.Abs(path)
+			absPath, err := filepath.Abs(path.Path)
 			if err != nil {
 				// If we can't get absolute path, use original path
-				absPath = path
+				absPath = path.Path
 			}
 			if _, exists := pathSet[absPath]; !exists {
 				pathSet[absPath] = struct{}{}
-				uniquePaths = append(uniquePaths, path)
+				uniquePaths = append(uniquePaths, absPath)
 			}
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -61,13 +61,13 @@ func TestMultiplePresetsWithDuplicatePaths(t *testing.T) {
 		}
 
 		for _, path := range processedPreset.Allow {
-			absPath, err := filepath.Abs(path)
+			absPath, err := filepath.Abs(path.Path)
 			if err != nil {
-				absPath = path
+				absPath = path.Path
 			}
 			if _, exists := pathSet[absPath]; !exists {
 				pathSet[absPath] = struct{}{}
-				uniquePaths = append(uniquePaths, path)
+				uniquePaths = append(uniquePaths, path.Path)
 			}
 		}
 	}
@@ -166,13 +166,13 @@ func TestPresetPathsWithRelativeAndAbsolute(t *testing.T) {
 		}
 
 		for _, path := range processedPreset.Allow {
-			absPath, err := filepath.Abs(path)
+			absPath, err := filepath.Abs(path.Path)
 			if err != nil {
-				absPath = path
+				absPath = path.Path
 			}
 			if _, exists := pathSet[absPath]; !exists {
 				pathSet[absPath] = struct{}{}
-				uniquePaths = append(uniquePaths, path)
+				uniquePaths = append(uniquePaths, path.Path)
 			}
 		}
 	}
@@ -231,13 +231,13 @@ func TestEnvironmentVariableExpansionDuplicates(t *testing.T) {
 		}
 
 		for _, path := range processedPreset.Allow {
-			absPath, err := filepath.Abs(path)
+			absPath, err := filepath.Abs(path.Path)
 			if err != nil {
-				absPath = path
+				absPath = path.Path
 			}
 			if _, exists := pathSet[absPath]; !exists {
 				pathSet[absPath] = struct{}{}
-				uniquePaths = append(uniquePaths, path)
+				uniquePaths = append(uniquePaths, path.Path)
 			}
 		}
 	}
@@ -309,13 +309,13 @@ func TestPresetOrderPreservation(t *testing.T) {
 		}
 
 		for _, path := range processedPreset.Allow {
-			absPath, err := filepath.Abs(path)
+			absPath, err := filepath.Abs(path.Path)
 			if err != nil {
-				absPath = path
+				absPath = path.Path
 			}
 			if _, exists := pathSet[absPath]; !exists {
 				pathSet[absPath] = struct{}{}
-				uniquePaths = append(uniquePaths, path)
+				uniquePaths = append(uniquePaths, path.Path)
 			}
 		}
 	}
@@ -397,13 +397,13 @@ auto-presets:
 		}
 
 		for _, path := range processedPreset.Allow {
-			absPath, err := filepath.Abs(path)
+			absPath, err := filepath.Abs(path.Path)
 			if err != nil {
-				absPath = path
+				absPath = path.Path
 			}
 			if _, exists := pathSet[absPath]; !exists {
 				pathSet[absPath] = struct{}{}
-				uniquePaths = append(uniquePaths, path)
+				uniquePaths = append(uniquePaths, path.Path)
 			}
 		}
 	}


### PR DESCRIPTION
This pull request introduces support for symlink evaluation in preset paths, refactors the handling of the `allow` field in presets, and updates related tests to accommodate the new functionality. The changes enhance flexibility in path configuration and ensure robust handling of symlinks.

### Enhancements to Preset Path Handling:
* **Support for Symlink Evaluation in Presets**: Added the ability to specify paths as objects with an `eval-symlinks` option, allowing symlinks to be resolved to their target paths before granting access. Updated documentation in `README.md` to explain usage and provide examples.
* **Refactored `allow` Field**: Replaced the `Allow` field in the `Preset` struct from `[]string` to `[]AllowPath`, which supports both string paths and objects with additional options like `eval-symlinks`. Introduced the `AllowPath` struct and its custom YAML unmarshalling logic in `config.go`. [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L21-R61) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L160-R205)

### Code Updates for Symlink Evaluation:
* **Processing Symlinks in Presets**: Updated the `ProcessPreset` method in `config.go` to resolve symlinks when `eval-symlinks` is enabled, with fallback handling for resolution errors. [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L160-R205) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L176-R215)
* **Handling Paths in `main.go`**: Adjusted path processing logic to use `AllowPath.Path` instead of raw strings, ensuring compatibility with the new structure.

### Test Suite Enhancements:
* **Updated Existing Tests**: Modified tests in `config_test.go` and `main_test.go` to use the new `AllowPath` structure. This includes tests for environment variable expansion, duplicates, and order preservation. [[1]](diffhunk://#diff-4bb821dfaef1884915ee03c5488bded04807301bc3f41fc7001a078c330ae980L94-R97) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL64-R70)
* **Added New Tests**: Introduced comprehensive tests for the `AllowPath` YAML unmarshalling logic and symlink evaluation in `config_test.go`, ensuring correctness and robustness of the new functionality.