### PR TITLE
fix: apply -allow-git flag even when using presets

### DIFF
--- a/config.go
+++ b/config.go
@@ -205,16 +205,5 @@ func (p *Preset) ProcessPreset() (*Preset, error) {
 		processed.Allow = append(processed.Allow, AllowPath{Path: expanded})
 	}
 
-	// Add git common directory if AllowGit is enabled
-	if p.AllowGit {
-		gitCommonDir, err := getGitCommonDir()
-		if err != nil {
-			// Log the error but don't fail - the directory might not be a git repo
-			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
-		} else {
-			processed.Allow = append(processed.Allow, AllowPath{Path: gitCommonDir})
-		}
-	}
-
 	return processed, nil
 }

--- a/dryrun.go
+++ b/dryrun.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// printDryRunAndExit displays the dry-run information and exits
+func printDryRunAndExit(config *SandboxConfig) {
+	modifySandboxConfig(config)
+	if err := showDryRun(config); err != nil {
+		fmt.Fprintf(os.Stderr, "cage: error showing dry-run: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/dryrun_darwin.go
+++ b/dryrun_darwin.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -19,7 +18,7 @@ func showDryRun(config *SandboxConfig) error {
 	fmt.Println("Rules:")
 
 	if config.AllowAll {
-		fmt.Println("- Allow all operations (--allow-all flag)")
+		fmt.Println("- Allow all operations (-allow-all flag)")
 	} else {
 		fmt.Println("- Allow all operations by default")
 		fmt.Println("- Deny all file writes")
@@ -27,7 +26,7 @@ func showDryRun(config *SandboxConfig) error {
 		fmt.Println("  * System temporary directories")
 
 		if config.AllowKeychain {
-			fmt.Println("  * Keychain directories (--allow-keychain)")
+			fmt.Println("  * Keychain directories (-allow-keychain)")
 		}
 
 		// Process allowed paths
@@ -38,7 +37,7 @@ func showDryRun(config *SandboxConfig) error {
 			}
 			source := "user specified"
 			if config.AllowGit && strings.Contains(path, ".git") {
-				source = "--allow-git"
+				source = "-allow-git"
 			}
 			fmt.Printf("  * %s (%s)\n", absPath, source)
 		}
@@ -64,13 +63,4 @@ func showDryRun(config *SandboxConfig) error {
 	fmt.Println()
 
 	return nil
-}
-
-// printDryRunAndExit displays the dry-run information and exits
-func printDryRunAndExit(config *SandboxConfig) {
-	if err := showDryRun(config); err != nil {
-		fmt.Fprintf(os.Stderr, "cage: error showing dry-run: %v\n", err)
-		os.Exit(1)
-	}
-	os.Exit(0)
 }

--- a/dryrun_linux.go
+++ b/dryrun_linux.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -21,7 +20,7 @@ func showDryRun(config *SandboxConfig) error {
 	fmt.Println("Rules:")
 
 	if config.AllowAll {
-		fmt.Println("- Allow all operations (--allow-all flag)")
+		fmt.Println("- Allow all operations (-allow-all flag)")
 	} else {
 		fmt.Println("- Allow read access to all files")
 		fmt.Println("- Deny write access except to:")
@@ -35,7 +34,7 @@ func showDryRun(config *SandboxConfig) error {
 			}
 			source := "user specified"
 			if config.AllowGit && strings.Contains(path, ".git") {
-				source = "--allow-git"
+				source = "-allow-git"
 			}
 			fmt.Printf("  * %s (%s)\n", absPath, source)
 		}
@@ -49,13 +48,4 @@ func showDryRun(config *SandboxConfig) error {
 	fmt.Println()
 
 	return nil
-}
-
-// printDryRunAndExit displays the dry-run information and exits
-func printDryRunAndExit(config *SandboxConfig) {
-	if err := showDryRun(config); err != nil {
-		fmt.Fprintf(os.Stderr, "cage: error showing dry-run: %v\n", err)
-		os.Exit(1)
-	}
-	os.Exit(0)
 }

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 	"strings"
 )
@@ -189,10 +188,6 @@ func main() {
 	allowKeychain := flags.allowKeychain
 	allowGit := flags.allowGit
 
-	// Track unique paths to avoid duplicates
-	pathSet := make(map[string]struct{})
-	var uniquePaths []string
-
 	// Process each preset and merge their settings
 	for _, presetName := range flags.presets {
 		preset, ok := config.GetPreset(presetName)
@@ -208,17 +203,9 @@ func main() {
 			os.Exit(1)
 		}
 
-		// Add preset paths, checking for duplicates
+		// Add preset paths
 		for _, path := range processedPreset.Allow {
-			absPath, err := filepath.Abs(path.Path)
-			if err != nil {
-				// If we can't get absolute path, use original path
-				absPath = path.Path
-			}
-			if _, exists := pathSet[absPath]; !exists {
-				pathSet[absPath] = struct{}{}
-				uniquePaths = append(uniquePaths, absPath)
-			}
+			allowedPaths = append(allowedPaths, path.Path)
 		}
 
 		// Preset's allowKeychain is ORed with command-line flag
@@ -226,33 +213,6 @@ func main() {
 
 		// Preset's allowGit is ORed with command-line flag
 		allowGit = allowGit || processedPreset.AllowGit
-	}
-
-	// Add command-line paths, checking for duplicates
-	for _, path := range allowedPaths {
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			// If we can't get absolute path, use original path
-			absPath = path
-		}
-		if _, exists := pathSet[absPath]; !exists {
-			pathSet[absPath] = struct{}{}
-			uniquePaths = append(uniquePaths, path)
-		}
-	}
-
-	// Replace allowedPaths with unique paths
-	allowedPaths = uniquePaths
-
-	// Add git common directory if allowGit is enabled and not already handled by preset
-	if allowGit && len(flags.presets) == 0 {
-		gitCommonDir, err := getGitCommonDir()
-		if err != nil {
-			// Log the error but don't fail - the directory might not be a git repo
-			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
-		} else {
-			allowedPaths = append(allowedPaths, gitCommonDir)
-		}
 	}
 
 	// Create sandbox configuration

--- a/sandbox_linux.go
+++ b/sandbox_linux.go
@@ -50,7 +50,7 @@ func runInSandbox(config *SandboxConfig) error {
 			rules = append(rules, landlock.RWDirs(path))
 			continue
 		}
-		
+
 		// Use appropriate rule based on file type
 		if info.IsDir() {
 			rules = append(rules, landlock.RWDirs(path))


### PR DESCRIPTION
This pull request refactors how allowed paths are managed and deduplicated throughout the application, centralizing this logic in a new `modifySandboxConfig` function. It also makes minor improvements to flag formatting in dry-run output and cleans up redundant code. The changes improve maintainability and ensure consistent handling of allowed paths, especially when using presets and the `--allow-git` flag.

**Path management and deduplication:**

* Introduced a new `modifySandboxConfig` function in `sandbox.go` to deduplicate and normalize allowed paths, and to add the git common directory if `AllowGit` is enabled. This logic is now called before running the sandbox and before displaying dry-run output, ensuring consistent path handling throughout the application. [[1]](diffhunk://#diff-ddb74f563edcc0f8d19dd0509ffcc1aa2b1a96aaa27e9ec821f8d87a70a3b577R34-R61) [[2]](diffhunk://#diff-ddb74f563edcc0f8d19dd0509ffcc1aa2b1a96aaa27e9ec821f8d87a70a3b577R3-R10)
* Removed path deduplication and git directory handling from `main.go` and `config.go`, delegating this responsibility to `modifySandboxConfig`. This simplifies the main application logic and avoids duplication of deduplication logic. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L192-L195) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L211-R208) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L231-L257) [[4]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L208-L218)

**Dry-run output improvements:**

* Refactored the dry-run code: moved `printDryRunAndExit` to a new `dryrun.go` file and updated it to use `modifySandboxConfig`, ensuring the dry-run output matches the actual sandbox configuration. [[1]](diffhunk://#diff-7a7088368c507966c50e9a7deb62483fc1f48946034c22d43e4c7c86fe590940R1-R16) [[2]](diffhunk://#diff-b0c50e76c2bc5be1b7d67f76ce6d63ad15672d1423df801e038baf68fb13dd9cL68-L76) [[3]](diffhunk://#diff-fb25ce1c72c2b17e3b5ded52907be9b13bf57d49f3a4bffff5d2d82056cc7322L53-L61)
* Updated flag formatting in dry-run output from `--allow-*` to `-allow-*` for consistency with the rest of the application. [[1]](diffhunk://#diff-b0c50e76c2bc5be1b7d67f76ce6d63ad15672d1423df801e038baf68fb13dd9cL22-R29) [[2]](diffhunk://#diff-b0c50e76c2bc5be1b7d67f76ce6d63ad15672d1423df801e038baf68fb13dd9cL41-R40) [[3]](diffhunk://#diff-fb25ce1c72c2b17e3b5ded52907be9b13bf57d49f3a4bffff5d2d82056cc7322L24-R23) [[4]](diffhunk://#diff-fb25ce1c72c2b17e3b5ded52907be9b13bf57d49f3a4bffff5d2d82056cc7322L38-R37)

**Code cleanup:**

* Removed unnecessary imports and old deduplication logic from `main.go`, `dryrun_darwin.go`, and `dryrun_linux.go` as path handling is now centralized. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L7) [[2]](diffhunk://#diff-b0c50e76c2bc5be1b7d67f76ce6d63ad15672d1423df801e038baf68fb13dd9cL7) [[3]](diffhunk://#diff-fb25ce1c72c2b17e3b5ded52907be9b13bf57d49f3a4bffff5d2d82056cc7322L7)