### PR TITLE
Add -deny flag to deny read access to specific paths

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,10 +26,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
           cache: "${{ github.event_name == 'push' }}"
+      - run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        if: runner.os == 'Linux'
       - run: go build
       - run: go test -v ./...
       - run: ./test_e2e.sh

--- a/CLI_DESIGN.md
+++ b/CLI_DESIGN.md
@@ -4,6 +4,7 @@
 Cage is a security-focused command-line tool that creates sandboxed environments for running untrusted or potentially dangerous commands. It provides unified sandboxing capabilities across Linux (using go-landlock) and macOS/Darwin (using sandbox-exec), ensuring consistent security policies across platforms.
 
 The primary goal of Cage is to prevent unintended file system modifications by restricting write access to only explicitly allowed paths, while maintaining full read access and network capabilities.
+Sensitive paths can also be explicitly denied from read access using the `-deny` flag.
 
 ## Command Structure
 
@@ -28,6 +29,9 @@ cage [flags] -- <command> [command-flags] [command-args...]
 ```bash
 --allow <path>     # Grant write access to specific paths (can be used multiple times)
                    # Example: --allow /tmp --allow $HOME/output
+--deny <path>      # Deny read access to specific paths (can be used multiple times)
+                   # On Linux, requires bubblewrap (bwrap)
+                   # Example: --deny ~/.ssh --deny ~/.env
 ```
 
 ## Usage Examples
@@ -64,7 +68,7 @@ cage --allow ./data -- python scraper.py --output ./data/results.json
 ## Important Notes
 
 ### Default Security Policy
-- **Read Access**: Unrestricted - commands can read any file the user has access to
+- **Read Access**: Unrestricted by default - use `--deny` flags to restrict sensitive paths
 - **Write Access**: Denied by default - must be explicitly granted using `--allow` flags
 - **Network Access**: Allowed - commands can make network connections
 - **Process Execution**: Allowed - commands can spawn child processes
@@ -81,6 +85,7 @@ cage --allow ./data -- python scraper.py --output ./data/results.json
 - Requires kernel version 5.13 or later
 - Uses the Landlock LSM (Linux Security Module) for fine-grained access control
 - Provides robust, kernel-level security guarantees
+- When `--deny` is specified, falls back to bubblewrap (bwrap) since Landlock uses an allowlist model
 
 **macOS (using sandbox-exec):**
 - Compatible with all modern macOS versions
@@ -108,6 +113,9 @@ cage python suspicious_script.py
 
 # Test third-party tools with minimal permissions
 cage --allow $HOME/safe-output -- third-party-tool process data.json
+
+# Deny access to sensitive files
+cage --allow . --deny ~/.ssh --deny ~/.env -- some-command
 ```
 
 ### Data Processing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cage
 
-A cross-platform security sandbox CLI tool that executes commands with restricted file system write access while maintaining full read permissions.
+A cross-platform security sandbox CLI tool that executes commands with restricted file system access.
 
 ## Overview
 
@@ -12,7 +12,8 @@ Cage provides a unified way to run potentially untrusted commands or scripts wit
 
 ## Features
 
-- **Write-only restriction**: Commands can read any file but cannot write unless explicitly allowed
+- **Write restriction**: Commands cannot write unless explicitly allowed via `-allow` flags
+- **Read restriction**: Deny read access to sensitive paths via `-deny` flag (on Linux requires bubblewrap)
 - **Cross-platform**: Works on Linux (kernel 5.13+) and macOS
 - **Flexible permissions**: Grant write access to specific paths via `-allow` flags
 - **Debug mode**: Disable all restrictions with `-allow-all`
@@ -54,6 +55,7 @@ cage [flags] <command> [args...]
 ### Flags
 
 - `-allow <path>`: Grant write access to a specific path (can be used multiple times)
+- `-deny <path>`: Deny read access to a specific path (can be used multiple times)
 - `-allow-keychain`: Allow write access to the macOS keychain (macOS only)
 - `-allow-git`: Allow access to git common directory (enables git operations in worktrees)
 - `-allow-all`: Disable all restrictions (useful for debugging)
@@ -88,6 +90,11 @@ cage -allow ./output -- ./process_data.sh /sensitive/data
 #### Allow keychain access (macOS)
 ```bash
 cage -allow-keychain -- security add-generic-password -s "MyService" -a "username" -w
+```
+
+#### Deny read access to sensitive files
+```bash
+cage -allow . -deny ~/.ssh -deny ~/.env -- some-command
 ```
 
 #### Debug mode (no restrictions)
@@ -172,12 +179,13 @@ presets:
 
 Presets support the following options:
 - `allow`: List of paths to grant write access (can be strings or objects with `eval-symlinks` option)
+- `deny`: List of paths to deny read access (can be strings or objects with `eval-symlinks` option)
 - `allow-git`: Enable access to git common directory (boolean)
 - `allow-keychain`: Enable macOS keychain access (boolean)
 
 #### Symlink Evaluation in Presets
 
-The `allow` field in presets supports both simple string paths and objects with an `eval-symlinks` option. When `eval-symlinks` is set to `true`, the symlink will be resolved to its target path before granting access.
+The `allow` and `deny` fields in presets support both simple string paths and objects with an `eval-symlinks` option. When `eval-symlinks` is set to `true`, the symlink will be resolved to its target path before applying the rule.
 
 ```yaml
 presets:
@@ -264,6 +272,7 @@ Auto-preset rules support:
 - Requires kernel 5.13 or later
 - Grants read/execute access to entire filesystem
 - Write access only to /dev/null and explicitly allowed paths
+- When `-deny` is specified, falls back to bubblewrap (see Limitations)
 
 ### macOS
 - Uses `sandbox-exec` with custom sandbox profiles
@@ -278,13 +287,14 @@ Auto-preset rules support:
 
 Cage enforces the following security policy by default:
 
-| Operation | Default Policy | With `-allow` |
-|-----------|---------------|----------------|
-| File Read | ✅ Allowed | ✅ Allowed |
-| File Write | ❌ Denied | ✅ Allowed for specified paths |
-| File Execute | ✅ Allowed | ✅ Allowed |
-| Network Access | ✅ Allowed | ✅ Allowed |
-| Process Creation | ✅ Allowed | ✅ Allowed |
+| Operation | Default Policy | With `-allow` | With `-deny` |
+|-----------|---------------|----------------|--------------------------|
+| File Read | ✅ Allowed | ✅ Allowed | ❌ Denied for specified paths |
+| File Write | ❌ Denied | ✅ Allowed for specified paths | ❌ Denied |
+| File Delete | ❌ Denied | ✅ Allowed for specified paths | ❌ Denied |
+| File Execute | ✅ Allowed | ✅ Allowed | ✅ Allowed |
+| Network Access | ✅ Allowed | ✅ Allowed | ✅ Allowed |
+| Process Creation | ✅ Allowed | ✅ Allowed | ✅ Allowed |
 
 ## Environment Variables
 
@@ -392,7 +402,7 @@ cage \
 - Sandboxing is only implemented for Linux and macOS
 - Linux requires kernel 5.13 or later for Landlock support
 - Network and process execution are not restricted
-- Cannot restrict reads (by design - focuses on write-only restrictions)
+- `-deny` flag on Linux requires [bubblewrap](https://github.com/containers/bubblewrap) to be installed
 
 ## Contributing
 

--- a/config.go
+++ b/config.go
@@ -18,12 +18,13 @@ type Config struct {
 }
 
 type Preset struct {
-	Allow         []AllowPath `yaml:"allow"`
-	AllowKeychain bool        `yaml:"allow-keychain"`
-	AllowGit      bool        `yaml:"allow-git"`
+	Allow         []PathSpec `yaml:"allow"`
+	Deny          []PathSpec `yaml:"deny"`
+	AllowKeychain bool       `yaml:"allow-keychain"`
+	AllowGit      bool       `yaml:"allow-git"`
 }
 
-type AllowPath struct {
+type PathSpec struct {
 	Path         string `yaml:"path"`
 	EvalSymLinks bool   `yaml:"eval-symlinks,omitempty"`
 }
@@ -34,28 +35,28 @@ type AutoPresetRule struct {
 	Presets        []string `yaml:"presets"`
 }
 
-func (p *AllowPath) UnmarshalYAML(b []byte) error {
+func (p *PathSpec) UnmarshalYAML(b []byte) error {
 	var a any
 	if err := yaml.Unmarshal(b, &a); err != nil {
-		return fmt.Errorf("unmarshal AllowPath: %w", err)
+		return fmt.Errorf("unmarshal PathSpec: %w", err)
 	}
 	switch v := a.(type) {
 	case string:
-		*p = AllowPath{
+		*p = PathSpec{
 			Path:         v,
 			EvalSymLinks: false,
 		}
 		return nil
 	case map[string]any:
-		type alias AllowPath
+		type alias PathSpec
 		var ap alias
 		if err := yaml.Unmarshal(b, &ap); err != nil {
-			return fmt.Errorf("unmarshal AllowPath map: %w", err)
+			return fmt.Errorf("unmarshal PathSpec map: %w", err)
 		}
-		*p = (AllowPath)(ap)
+		*p = (PathSpec)(ap)
 		return nil
 	default:
-		return fmt.Errorf("unmarshal AllowPath: unsupported type %T", a)
+		return fmt.Errorf("unmarshal PathSpec: unsupported type %T", a)
 	}
 }
 
@@ -182,27 +183,32 @@ func getGitCommonDir() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+// resolvePath expands environment variables and optionally resolves symlinks.
+func resolvePath(p PathSpec) string {
+	expanded := os.ExpandEnv(p.Path)
+	if p.EvalSymLinks {
+		if resolved, err := filepath.EvalSymlinks(expanded); err == nil {
+			expanded = resolved
+		}
+	}
+	return expanded
+}
+
 // ProcessPreset expands all dynamic values in a preset
 func (p *Preset) ProcessPreset() (*Preset, error) {
 	processed := &Preset{
 		AllowKeychain: p.AllowKeychain,
 		AllowGit:      p.AllowGit,
-		Allow:         make([]AllowPath, 0, len(p.Allow)),
+		Allow:         make([]PathSpec, 0, len(p.Allow)),
+		Deny:          make([]PathSpec, 0, len(p.Deny)),
 	}
 
-	// Expand environment variables in paths
 	for _, path := range p.Allow {
-		expanded := os.ExpandEnv(path.Path)
-		if path.EvalSymLinks {
-			// Resolve symlinks if EvalSymLinks is true
-			resolvedPath, err := filepath.EvalSymlinks(expanded)
-			if err != nil {
-				resolvedPath = expanded // Fallback to original path if eval fails
-			}
-			expanded = resolvedPath
-		}
+		processed.Allow = append(processed.Allow, PathSpec{Path: resolvePath(path)})
+	}
 
-		processed.Allow = append(processed.Allow, AllowPath{Path: expanded})
+	for _, path := range p.Deny {
+		processed.Deny = append(processed.Deny, PathSpec{Path: resolvePath(path)})
 	}
 
 	return processed, nil

--- a/config_test.go
+++ b/config_test.go
@@ -94,7 +94,7 @@ func TestConfigGetPreset(t *testing.T) {
 	config := &Config{
 		Presets: map[string]Preset{
 			"test": {
-				Allow: []AllowPath{{Path: "/tmp"}, {Path: "/var"}},
+				Allow: []PathSpec{{Path: "/tmp"}, {Path: "/var"}},
 			},
 		},
 	}
@@ -135,9 +135,9 @@ func TestConfigGetPreset(t *testing.T) {
 func TestConfigListPresets(t *testing.T) {
 	config := &Config{
 		Presets: map[string]Preset{
-			"npm":   {Allow: []AllowPath{{Path: "~/.npm"}}},
-			"cargo": {Allow: []AllowPath{{Path: "~/.cargo"}}},
-			"pip":   {Allow: []AllowPath{{Path: "~/.pip"}}},
+			"npm":   {Allow: []PathSpec{{Path: "~/.npm"}}},
+			"cargo": {Allow: []PathSpec{{Path: "~/.cargo"}}},
+			"pip":   {Allow: []PathSpec{{Path: "~/.pip"}}},
 		},
 	}
 
@@ -228,7 +228,7 @@ func TestProcessPreset(t *testing.T) {
 		{
 			name: "preset with environment variables",
 			preset: Preset{
-				Allow: []AllowPath{
+				Allow: []PathSpec{
 					{Path: "$HOME/.npm"},
 					{Path: "${TEST_DIR}/data"},
 					{Path: "/tmp"},
@@ -245,7 +245,7 @@ func TestProcessPreset(t *testing.T) {
 		{
 			name: "preset with command substitution not expanded",
 			preset: Preset{
-				Allow: []AllowPath{
+				Allow: []PathSpec{
 					{Path: "$(echo /dynamic/path)"},
 				},
 			},
@@ -351,7 +351,7 @@ func TestProcessPresetWithAllowGit(t *testing.T) {
 	// This test will only check the AllowGit flag is preserved
 	// We can't easily test the git directory addition without a real git repo
 	preset := Preset{
-		Allow: []AllowPath{
+		Allow: []PathSpec{
 			{Path: "$HOME/.npm"},
 			{Path: "/tmp"},
 		},
@@ -404,9 +404,9 @@ func TestProcessPresetWithAllowGit(t *testing.T) {
 func TestGetAutoPresets(t *testing.T) {
 	config := &Config{
 		Presets: map[string]Preset{
-			"claude-code": {Allow: []AllowPath{{Path: "/tmp"}}},
-			"npm":         {Allow: []AllowPath{{Path: "~/.npm"}}},
-			"python":      {Allow: []AllowPath{{Path: "~/.python"}}},
+			"claude-code": {Allow: []PathSpec{{Path: "/tmp"}}},
+			"npm":         {Allow: []PathSpec{{Path: "~/.npm"}}},
+			"python":      {Allow: []PathSpec{{Path: "~/.python"}}},
 		},
 		AutoPresets: []AutoPresetRule{
 			{
@@ -595,18 +595,18 @@ auto-presets:
 	}
 }
 
-func TestAllowPathUnmarshalYAML(t *testing.T) {
+func TestPathSpecUnmarshalYAML(t *testing.T) {
 	tests := []struct {
 		name     string
 		yaml     string
-		want     AllowPath
+		want     PathSpec
 		wantErr  bool
 		errMatch string
 	}{
 		{
 			name: "string format",
 			yaml: `"/tmp/test"`,
-			want: AllowPath{
+			want: PathSpec{
 				Path:         "/tmp/test",
 				EvalSymLinks: false,
 			},
@@ -616,7 +616,7 @@ func TestAllowPathUnmarshalYAML(t *testing.T) {
 			name: "object format with eval-symlinks false",
 			yaml: `path: "/tmp/test"
 eval-symlinks: false`,
-			want: AllowPath{
+			want: PathSpec{
 				Path:         "/tmp/test",
 				EvalSymLinks: false,
 			},
@@ -626,7 +626,7 @@ eval-symlinks: false`,
 			name: "object format with eval-symlinks true",
 			yaml: `path: "/tmp/test"
 eval-symlinks: true`,
-			want: AllowPath{
+			want: PathSpec{
 				Path:         "/tmp/test",
 				EvalSymLinks: true,
 			},
@@ -635,7 +635,7 @@ eval-symlinks: true`,
 		{
 			name: "object format without eval-symlinks",
 			yaml: `path: "/tmp/test"`,
-			want: AllowPath{
+			want: PathSpec{
 				Path:         "/tmp/test",
 				EvalSymLinks: false,
 			},
@@ -663,7 +663,7 @@ eval-symlinks: true`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var ap AllowPath
+			var ap PathSpec
 			err := yaml.Unmarshal([]byte(tt.yaml), &ap)
 
 			if (err != nil) != tt.wantErr {
@@ -698,7 +698,7 @@ eval-symlinks: true`,
 	}
 }
 
-func TestLoadConfigWithAllowPathFormats(t *testing.T) {
+func TestLoadConfigWithPathSpecFormats(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "test.yaml")
 	content := `presets:
@@ -768,7 +768,7 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 		{
 			name: "symlink evaluation disabled",
 			preset: Preset{
-				Allow: []AllowPath{
+				Allow: []PathSpec{
 					{Path: symlinkPath, EvalSymLinks: false},
 				},
 			},
@@ -777,7 +777,7 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 		{
 			name: "symlink evaluation enabled",
 			preset: Preset{
-				Allow: []AllowPath{
+				Allow: []PathSpec{
 					{Path: symlinkPath, EvalSymLinks: true},
 				},
 			},
@@ -786,7 +786,7 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 		{
 			name: "mix of symlink and regular paths",
 			preset: Preset{
-				Allow: []AllowPath{
+				Allow: []PathSpec{
 					{Path: "/tmp", EvalSymLinks: false},
 					{Path: symlinkPath, EvalSymLinks: true},
 					{Path: "/var", EvalSymLinks: false},
@@ -797,7 +797,7 @@ func TestProcessPresetWithSymlinkEvaluation(t *testing.T) {
 		{
 			name: "non-existent symlink falls back to original path",
 			preset: Preset{
-				Allow: []AllowPath{
+				Allow: []PathSpec{
 					{Path: "/non/existent/symlink", EvalSymLinks: true},
 				},
 			},

--- a/dryrun_darwin.go
+++ b/dryrun_darwin.go
@@ -41,6 +41,17 @@ func showDryRun(config *SandboxConfig) error {
 			}
 			fmt.Printf("  * %s (%s)\n", absPath, source)
 		}
+
+		if len(config.DeniedPaths) > 0 {
+			fmt.Println("- Deny read access to:")
+			for _, path := range config.DeniedPaths {
+				absPath, err := filepath.Abs(path)
+				if err != nil {
+					absPath = path
+				}
+				fmt.Printf("  * %s\n", absPath)
+			}
+		}
 	}
 
 	fmt.Println()

--- a/dryrun_linux.go
+++ b/dryrun_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -13,7 +14,16 @@ func showDryRun(config *SandboxConfig) error {
 	fmt.Println("Sandbox Profile (dry-run):")
 	fmt.Println("========================================")
 	fmt.Println("Platform: Linux")
-	fmt.Println("Technology: Landlock LSM")
+	if len(config.DeniedPaths) > 0 {
+		fmt.Println("Technology: bubblewrap (bwrap)")
+		if _, err := exec.LookPath("bwrap"); err != nil {
+			fmt.Println(
+				"WARNING: bubblewrap (bwrap) is not installed; -deny flag will fail at runtime",
+			)
+		}
+	} else {
+		fmt.Println("Technology: Landlock LSM")
+	}
 	fmt.Println()
 	fmt.Println("The following restrictions would be applied:")
 	fmt.Println()
@@ -37,6 +47,17 @@ func showDryRun(config *SandboxConfig) error {
 				source = "-allow-git"
 			}
 			fmt.Printf("  * %s (%s)\n", absPath, source)
+		}
+
+		if len(config.DeniedPaths) > 0 {
+			fmt.Println("- Deny read access to:")
+			for _, path := range config.DeniedPaths {
+				absPath, err := filepath.Abs(path)
+				if err != nil {
+					absPath = path
+				}
+				fmt.Printf("  * %s\n", absPath)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type flags struct {
 	allowKeychain bool
 	allowGit      bool
 	allowPaths    []string
+	denyPaths     []string
 	presets       []string
 	listPresets   bool
 	configPath    string
@@ -66,6 +67,14 @@ func parseFlags() (*flags, []string) {
 		&allowFlags,
 		"allow",
 		"Grant write access to specific paths (can be used multiple times)",
+	)
+
+	// Custom flag parsing to handle multiple --deny flags
+	var denyFlags arrayFlags
+	flag.Var(
+		&denyFlags,
+		"deny",
+		"Deny read access to specific paths (can be used multiple times; on Linux requires bwrap)",
 	)
 
 	// Custom flag parsing to handle multiple --preset flags
@@ -107,6 +116,7 @@ func parseFlags() (*flags, []string) {
 	flag.Parse()
 
 	f.allowPaths = []string(allowFlags)
+	f.denyPaths = []string(denyFlags)
 	f.presets = []string(presetFlags)
 
 	return f, flag.Args()
@@ -185,6 +195,7 @@ func main() {
 
 	// Merge preset paths with command-line paths
 	allowedPaths := flags.allowPaths
+	deniedPaths := flags.denyPaths
 	allowKeychain := flags.allowKeychain
 	allowGit := flags.allowGit
 
@@ -208,6 +219,11 @@ func main() {
 			allowedPaths = append(allowedPaths, path.Path)
 		}
 
+		// Add preset deny paths
+		for _, path := range processedPreset.Deny {
+			deniedPaths = append(deniedPaths, path.Path)
+		}
+
 		// Preset's allowKeychain is ORed with command-line flag
 		allowKeychain = allowKeychain || processedPreset.AllowKeychain
 
@@ -221,8 +237,15 @@ func main() {
 		AllowKeychain: allowKeychain,
 		AllowGit:      allowGit,
 		AllowedPaths:  allowedPaths,
+		DeniedPaths:   deniedPaths,
 		Command:       args[0],
 		Args:          args[1:],
+	}
+
+	// Validate flag combinations
+	if sandboxConfig.AllowAll && len(sandboxConfig.DeniedPaths) > 0 {
+		fmt.Fprintf(os.Stderr, "cage: cannot use -allow-all with -deny\n")
+		os.Exit(1)
 	}
 
 	// Handle dry-run flag

--- a/sandbox.go
+++ b/sandbox.go
@@ -24,6 +24,10 @@ type SandboxConfig struct {
 	// AllowedPaths are paths where write access is granted
 	AllowedPaths []string
 
+	// DeniedPaths are paths where read access is denied
+	// On macOS, uses sandbox-exec. On Linux, uses bubblewrap (bwrap) as fallback.
+	DeniedPaths []string
+
 	// Command is the command to execute
 	Command string
 
@@ -53,6 +57,16 @@ func modifySandboxConfig(config *SandboxConfig) {
 	}
 
 	config.AllowedPaths = slices.Sorted(maps.Keys(pathSet))
+
+	deniedSet := make(map[string]struct{})
+	for _, path := range config.DeniedPaths {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			absPath = path
+		}
+		deniedSet[absPath] = struct{}{}
+	}
+	config.DeniedPaths = slices.Sorted(maps.Keys(deniedSet))
 }
 
 // RunInSandbox executes the given command with sandbox restrictions

--- a/sandbox_darwin.go
+++ b/sandbox_darwin.go
@@ -73,14 +73,21 @@ func generateSandboxProfile(config *SandboxConfig) (string, error) {
 			absPath = path
 		}
 
+		// Check if the path exists before adding the rule
+		info, err := os.Stat(absPath)
+		if err != nil {
+			continue
+		}
+
 		// Escape the path for the sandbox profile
 		escapedPath := escapePathForSandbox(absPath)
 
-		// Allow writes to the path and all subpaths
-		fmt.Fprintf(&profile, "(allow file-write* (subpath \"%s\"))\n", escapedPath)
-
-		// Also allow writes to the literal path (for directory creation)
-		fmt.Fprintf(&profile, "(allow file-write* (literal \"%s\"))\n", escapedPath)
+		// Use subpath for directories, literal for files
+		if info.IsDir() {
+			fmt.Fprintf(&profile, "(allow file-write* (subpath \"%s\"))\n", escapedPath)
+		} else {
+			fmt.Fprintf(&profile, "(allow file-write* (literal \"%s\"))\n", escapedPath)
+		}
 	}
 
 	return profile.String(), nil

--- a/sandbox_darwin.go
+++ b/sandbox_darwin.go
@@ -90,6 +90,36 @@ func generateSandboxProfile(config *SandboxConfig) (string, error) {
 		}
 	}
 
+	// Deny read access to specified paths (placed last to take priority over allow rules)
+	for _, path := range config.DeniedPaths {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			absPath = path
+		}
+
+		// Check if the path exists before adding the rule
+		info, err := os.Stat(absPath)
+		if err != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"cage: warning: deny path does not exist, skipping: %s\n",
+				absPath,
+			)
+			continue
+		}
+
+		escapedPath := escapePathForSandbox(absPath)
+
+		// Use subpath for directories, literal for files
+		// Use file-read-data instead of file-read* to allow metadata access (e.g. stat).
+		// The goal is to prevent reading file contents, not to hide the existence of files.
+		if info.IsDir() {
+			fmt.Fprintf(&profile, "(deny file-read-data (subpath \"%s\"))\n", escapedPath)
+		} else {
+			fmt.Fprintf(&profile, "(deny file-read-data (literal \"%s\"))\n", escapedPath)
+		}
+	}
+
 	return profile.String(), nil
 }
 

--- a/sandbox_linux.go
+++ b/sandbox_linux.go
@@ -27,6 +27,12 @@ func runInSandbox(config *SandboxConfig) error {
 		return syscall.Exec(path, argv, os.Environ())
 	}
 
+	// Fall back to bubblewrap when DeniedPaths are specified,
+	// since Landlock LSM uses an allowlist model and cannot deny reads.
+	if len(config.DeniedPaths) > 0 {
+		return runWithBubblewrap(config)
+	}
+
 	// Build FSRules
 	var rules []landlock.Rule
 
@@ -81,4 +87,59 @@ func runInSandbox(config *SandboxConfig) error {
 	err = syscall.Exec(path, argv, os.Environ())
 	// If we reach here, exec failed
 	return fmt.Errorf("syscall.Exec failed: %w", err)
+}
+
+// runWithBubblewrap implements sandbox execution for Linux using bubblewrap (bwrap)
+// This is used as a fallback when DeniedPaths are specified, since Landlock does not support deny rules.
+func runWithBubblewrap(config *SandboxConfig) error {
+	bwrapPath, err := exec.LookPath("bwrap")
+	if err != nil {
+		return fmt.Errorf("-deny flag on Linux requires bubblewrap (bwrap): %w", err)
+	}
+
+	args := []string{"bwrap"}
+
+	// Bind the entire root filesystem as read-only (equivalent to Landlock's RODirs("/"))
+	args = append(args, "--ro-bind", "/", "/")
+
+	// Allow write access to /dev/null by default (equivalent to Landlock's RWFiles("/dev/null"))
+	args = append(args, "--dev-bind", "/dev/null", "/dev/null")
+
+	// Grant write access to specified paths
+	for _, path := range config.AllowedPaths {
+		// Check if the path exists before adding the rule
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		// Use --dev-bind for /dev and paths under /dev/ (equivalent to Landlock's WithIoctlDev)
+		if path == "/dev" || strings.HasPrefix(path, "/dev/") {
+			args = append(args, "--dev-bind", path, path)
+			continue
+		}
+		// Use --bind for other paths (works for both files and directories)
+		args = append(args, "--bind", path, path)
+	}
+
+	// Deny read access to specified paths (placed last to take priority over allow rules)
+	for _, path := range config.DeniedPaths {
+		// Check if the path exists before adding the rule
+		info, err := os.Stat(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cage: warning: deny path does not exist, skipping: %s\n", path)
+			continue
+		}
+		if info.IsDir() {
+			// Directory: mount tmpfs to hide contents
+			args = append(args, "--tmpfs", path)
+		} else {
+			// File: bind /dev/null over the file to make it appear empty
+			args = append(args, "--bind", "/dev/null", path)
+		}
+	}
+
+	args = append(args, "--")
+	args = append(args, config.Command)
+	args = append(args, config.Args...)
+
+	return syscall.Exec(bwrapPath, args, os.Environ())
 }

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -195,10 +195,64 @@ test_edge_cases() {
         "$CAGE_BIN" cat /etc/passwd
 }
 
+# Test 8: Single directory deny
+test_single_deny() {
+    echo -e "\nTesting single --deny flag..."
+
+    mkdir -p "$TEST_DIR/secret"
+    echo "secret content" > "$TEST_DIR/secret/secret.txt"
+    echo "secret file" > "$TEST_DIR/secret_file.txt"
+
+    run_test "Read denied directory (should fail)" "failure" \
+        "$CAGE_BIN" -deny "$TEST_DIR/secret" cat "$TEST_DIR/secret/secret.txt"
+
+    run_test "Read denied file (should fail)" "failure" \
+        "$CAGE_BIN" -deny "$TEST_DIR/secret_file.txt" cat "$TEST_DIR/secret_file.txt"
+
+    run_test "Read non-denied file" "success" \
+        "$CAGE_BIN" -deny "$TEST_DIR/secret" cat "$TEST_DIR/readable/test.txt"
+}
+
+# Test 9: Multiple directory deny
+test_multiple_deny() {
+    echo -e "\nTesting multiple --deny flags..."
+
+    mkdir -p "$TEST_DIR/secret2"
+    echo "secret2 content" > "$TEST_DIR/secret2/secret2.txt"
+
+    run_test "Read first denied directory (should fail)" "failure" \
+        "$CAGE_BIN" -deny "$TEST_DIR/secret" -deny "$TEST_DIR/secret2" cat "$TEST_DIR/secret/secret.txt"
+
+    run_test "Read second denied directory (should fail)" "failure" \
+        "$CAGE_BIN" -deny "$TEST_DIR/secret" -deny "$TEST_DIR/secret2" cat "$TEST_DIR/secret2/secret2.txt"
+
+    run_test "Read non-denied file with multiple --deny" "success" \
+        "$CAGE_BIN" -deny "$TEST_DIR/secret" -deny "$TEST_DIR/secret2" cat "$TEST_DIR/readable/test.txt"
+}
+
+# Test 10: Deny with allow flag
+test_deny_with_allow() {
+    echo -e "\nTesting -deny flag with -allow flag..."
+
+    run_test "Read denied directory with --allow (should fail)" "failure" \
+        "$CAGE_BIN" -allow "$TEST_DIR" -deny "$TEST_DIR/secret" cat "$TEST_DIR/secret/secret.txt"
+
+    run_test "Read non-denied file with --allow and --deny" "success" \
+        "$CAGE_BIN" -allow "$TEST_DIR" -deny "$TEST_DIR/secret" cat "$TEST_DIR/readable/test.txt"
+}
+
+# Test 11: Deny with allow-all flag
+test_deny_with_allow_all() {
+    echo -e "\nTesting -deny flag with --allow-all flag..."
+
+    run_test "Use --allow-all with --deny (should fail)" "failure" \
+        "$CAGE_BIN" -allow-all -deny "$TEST_DIR/secret" cat "$TEST_DIR/secret/secret.txt"
+}
+
 # Platform-specific tests
 test_platform_specific() {
     echo -e "\nTesting platform-specific features..."
-    
+
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         echo "Running Linux-specific tests..."
         # Linux specific tests here
@@ -213,9 +267,9 @@ main() {
     echo "=== Cage E2E Test Suite ==="
     echo "Platform: $OSTYPE"
     echo
-    
+
     setup
-    
+
     test_basic_execution
     test_write_restrictions
     test_single_allow
@@ -223,6 +277,10 @@ main() {
     test_allow_all
     test_complex_commands
     test_edge_cases
+    test_single_deny
+    test_multiple_deny
+    test_deny_with_allow
+    test_deny_with_allow_all
     test_platform_specific
     
     echo


### PR DESCRIPTION
## Summary

Closes #85

- Add `-deny <path>` flag (repeatable) to deny read access to specific paths
- Support `deny` key in config presets with the same `eval-symlinks` option as `allow`
- Warn when a denied path does not exist at sandbox startup
- Refactor `AllowPath` to `PathSpec` to reflect its use for both allow and deny entries

## Platform behavior

**macOS**: Uses `deny file-read-data` in the sandbox-exec profile. The process receives a permission denied error when attempting to read a denied path.

**Linux**: Landlock LSM uses an allowlist model — it can grant access to specific paths but cannot explicitly deny reads. Therefore, when `-deny` is specified, cage falls back to bubblewrap (bwrap). Denied directories are hidden with a tmpfs mount; denied files are masked with `/dev/null`.